### PR TITLE
chore: only run the lint workflow when go files changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on:
   pull_request:
+    paths:
+      - '**/*.go'
 
 permissions:
   contents: read


### PR DESCRIPTION
Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
