### PR TITLE
chore: bump the manifest for the new release

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: mcp
 repository: github.com/aquasecurity/trivy-mcp
 maintainer: aquasecurity
-version: 0.0.5
+version: 0.0.6
 summary: Starts an MCP server that knows how to work with Trivy
 description: |-
   A Trivy plugin that starts an MCP server that knows how to work with Trivy.
@@ -10,25 +10,25 @@ platforms:
     - selector:
         os: linux
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.5/trivy-mcp-linux-amd64.tar.gz
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.6/trivy-mcp-linux-amd64.tar.gz
       bin: ./trivy-mcp
     - selector:
         os: linux
         arch: arm64
-      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.5/trivy-mcp-linux-arm64.tar.gz
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.6/trivy-mcp-linux-arm64.tar.gz
       bin: ./trivy-mcp
     - selector:
         os: darwin
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.5/trivy-mcp-darwin-amd64.tar.gz
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.6/trivy-mcp-darwin-amd64.tar.gz
       bin: ./trivy-mcp
     - selector:
         os: darwin
         arch: arm64
-      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.5/trivy-mcp-darwin-arm64.tar.gz
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.6/trivy-mcp-darwin-arm64.tar.gz
       bin: ./trivy-mcp
     - selector:
         os: windows
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.5/trivy-mcp-windows-amd64.tar.gz
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.6/trivy-mcp-windows-amd64.tar.gz
       bin: ./trivy-mcp


### PR DESCRIPTION
plugin manifest needs to reflect the version being released

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
