### PR TITLE
feat(scan): add optional branch parameter to scan_repository

### DIFF
--- a/pkg/tools/scan/scan.go
+++ b/pkg/tools/scan/scan.go
@@ -98,18 +98,14 @@ Follow the instructions that are given in the response.`),
 		outputFormatString,
 		fixedOnlyBool,
 		targetTypeString("repository"),
+		branchString,
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			Title: "Scan a remote git repository with Trivy",
 		}),
 	)
 )
 
-func (t *ScanTools) ScanWithTrivyHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	scanArgs, err := parseScanArgs(request)
-	if err != nil {
-		return nil, err
-	}
-
+func buildBaseArgs(scanArgs *scanArgs, debug bool) []string {
 	args := []string{
 		scanArgs.targetType,
 		fmt.Sprintf("--scanners=%s", strings.Join(scanArgs.scanType, ",")),
@@ -117,7 +113,7 @@ func (t *ScanTools) ScanWithTrivyHandler(ctx context.Context, request mcp.CallTo
 		fmt.Sprintf("--format=%s", scanArgs.outputFormat),
 	}
 
-	if t.debug {
+	if debug {
 		args = append(args, "--debug")
 	}
 
@@ -130,6 +126,22 @@ func (t *ScanTools) ScanWithTrivyHandler(ctx context.Context, request mcp.CallTo
 	if scanArgs.outputFormat == "json" && slices.Contains(scanArgs.scanType, "vuln") {
 		args = append(args, "--list-all-pkgs")
 	}
+
+	// Scan a specific Git branch/tag when requested (repository scans only).
+	if scanArgs.targetType == "repository" && scanArgs.branch != "" {
+		args = append(args, fmt.Sprintf("--branch=%s", scanArgs.branch))
+	}
+
+	return args
+}
+
+func (t *ScanTools) ScanWithTrivyHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	scanArgs, err := parseScanArgs(request)
+	if err != nil {
+		return nil, err
+	}
+
+	args := buildBaseArgs(scanArgs, t.debug)
 
 	// aquaPlatform only supports filesystem scans at the moment
 	if t.useAquaPlatform && scanArgs.targetType == "filesystem" {
@@ -210,6 +222,7 @@ func (t *ScanTools) ScanWithTrivyHandler(ctx context.Context, request mcp.CallTo
 			"severities":   strings.Join(scanArgs.severities, ","),
 			"outputFormat": scanArgs.outputFormat,
 			"fixedOnly":    fmt.Sprintf("%t", scanArgs.fixedOnly),
+			"branch":       scanArgs.branch,
 		},
 		Next: Next{
 			Tool: "findings_list",

--- a/pkg/tools/scan/scan_args.go
+++ b/pkg/tools/scan/scan_args.go
@@ -14,6 +14,7 @@ type scanArgs struct {
 	outputFormat string
 	isSBOM       bool
 	fixedOnly    bool
+	branch       string
 }
 
 var (
@@ -72,6 +73,10 @@ var fixedOnlyBool = mcp.WithBoolean("fixedOnly",
 	mcp.DefaultBool(false),
 )
 
+var branchString = mcp.WithString("branch",
+	mcp.Description("Git branch or tag to scan. Only used when targetType is repository. If omitted, the repository's default branch is scanned."),
+)
+
 func targetTypeString(expectedValue string) mcp.ToolOption {
 	return mcp.WithString("targetType",
 		mcp.Required(),
@@ -115,6 +120,7 @@ func parseScanArgs(request mcp.CallToolRequest) (*scanArgs, error) {
 	if !ok {
 		fixedOnlyBool = false
 	}
+	branch, _ := args["branch"].(string)
 
 	return &scanArgs{
 		target:       target,
@@ -124,5 +130,6 @@ func parseScanArgs(request mcp.CallToolRequest) (*scanArgs, error) {
 		outputFormat: outputFormat,
 		isSBOM:       outputFormat == "cyclonedx" || outputFormat == "spdx" || outputFormat == "spdx-json",
 		fixedOnly:    fixedOnlyBool,
+		branch:       branch,
 	}, nil
 }

--- a/pkg/tools/scan/scan_args_test.go
+++ b/pkg/tools/scan/scan_args_test.go
@@ -42,6 +42,36 @@ func TestScanArgsCorrectlyParsed(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "Repository scan with branch",
+			request: mcp.CallToolRequest{
+				Params: struct {
+					Name      string    `json:"name"`
+					Arguments any       `json:"arguments,omitempty"`
+					Meta      *mcp.Meta `json:"_meta,omitempty"`
+				}{
+					Name: "scan_repository",
+					Arguments: map[string]any{
+						"target":       "https://github.com/acme/infra",
+						"targetType":   "repository",
+						"scanType":     []any{"vuln", "misconfig", "secret"},
+						"severities":   []any{"MEDIUM"},
+						"outputFormat": "json",
+						"branch":       "feature/add-vm",
+					},
+					Meta: nil,
+				},
+			},
+			expected: &scanArgs{
+				target:       "https://github.com/acme/infra",
+				targetType:   "repository",
+				scanType:     []string{"vuln", "misconfig", "secret"},
+				severities:   []string{"MEDIUM"},
+				outputFormat: "json",
+				branch:       "feature/add-vm",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tools/scan/scan_test.go
+++ b/pkg/tools/scan/scan_test.go
@@ -8,6 +8,81 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuildBaseArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     *scanArgs
+		debug    bool
+		expected []string
+	}{
+		{
+			name: "repository scan with branch",
+			args: &scanArgs{
+				target:       "https://github.com/acme/infra",
+				targetType:   "repository",
+				scanType:     []string{"vuln", "misconfig", "secret"},
+				severities:   []string{"MEDIUM"},
+				outputFormat: "json",
+				branch:       "feature/add-vm",
+			},
+			debug: false,
+			expected: []string{
+				"repository",
+				"--scanners=vuln,misconfig,secret",
+				"--severity=MEDIUM",
+				"--format=json",
+				"--list-all-pkgs",
+				"--branch=feature/add-vm",
+			},
+		},
+		{
+			name: "repository scan without branch omits flag",
+			args: &scanArgs{
+				target:       "https://github.com/acme/infra",
+				targetType:   "repository",
+				scanType:     []string{"vuln"},
+				severities:   []string{"CRITICAL"},
+				outputFormat: "json",
+			},
+			debug: false,
+			expected: []string{
+				"repository",
+				"--scanners=vuln",
+				"--severity=CRITICAL",
+				"--format=json",
+				"--list-all-pkgs",
+			},
+		},
+		{
+			name: "filesystem scan ignores branch",
+			args: &scanArgs{
+				target:       "/tmp/project",
+				targetType:   "filesystem",
+				scanType:     []string{"vuln"},
+				severities:   []string{"HIGH"},
+				outputFormat: "json",
+				branch:       "feature/add-vm",
+			},
+			debug: true,
+			expected: []string{
+				"filesystem",
+				"--scanners=vuln",
+				"--severity=HIGH",
+				"--format=json",
+				"--debug",
+				"--list-all-pkgs",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBaseArgs(tt.args, tt.debug)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestNewScanTools(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Adds an optional `branch` parameter to the `scan_repository` MCP tool so callers can scan a specific Git branch or tag instead of always scanning the repository's default branch.

This is especially useful for PR-review workflows where the target of the review is the PR head branch, not `main`.

## Change

- `pkg/tools/scan/scan_args.go`
  - Added `branch` to `scanArgs`.
  - Added optional `branch` tool option.
  - Parse `branch` from the request arguments.
- `pkg/tools/scan/scan.go`
  - Added `branch` to `ScanRepositoryTool` schema.
  - For repository scans, append `--branch=<ref>` to the Trivy CLI arguments when `branch` is provided.
  - Include `branch` in the scan response metadata.
  - Extracted `buildBaseArgs` to make the generated CLI arguments testable.
- `pkg/tools/scan/scan_args_test.go` / `scan_test.go`
  - Added tests for parsing and building arguments with `branch`.

## Usage example

```
scan_repository(
  target="https://github.com/acme/infra",
  branch="feature/add-vm",
  scanType=["vuln", "misconfig", "secret"],
  outputFormat="json",
  targetType="repository",
  severities=["MEDIUM"]
)
```
This maps to:
```
trivy repo --scanners=vuln,misconfig,secret \
           --severity=MEDIUM \
           --format=json \
           --list-all-pkgs \
           --branch=feature/add-vm \
           https://github.com/acme/infra
```
Backward compatibility

Existing calls without branch behave identically — Trivy scans the repository's default branch, as before.

Testing

- go test ./pkg/tools/scan/... passes.
- go test ./... passes.
- Manually verified by scanning a non-default branch with the MCP server.